### PR TITLE
return the block.call results

### DIFF
--- a/lib/once/version.rb
+++ b/lib/once/version.rb
@@ -1,3 +1,3 @@
 module Once
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/spec/once_spec.rb
+++ b/spec/once_spec.rb
@@ -8,7 +8,7 @@ describe Once do
     Once.redis = Redis.new
   end
 
-  let(:thing_to_execute)  { double(execute: nil) }
+  let(:thing_to_execute)  { double(execute: "foo") }
   let(:params) {{foo: "bar"}}
 
   it "executes the given command" do
@@ -17,6 +17,12 @@ describe Once do
     end
 
     thing_to_execute.should have_received(:execute).once
+  end
+
+  it "returns the result of the command" do
+    described_class.do(name: "mycheck", params: params) do
+      thing_to_execute.execute
+    end.should == "foo"
   end
 
   it "executes when called from within different namespaces" do


### PR DESCRIPTION
Wrapping a block of code with Once will now return the results of the block, making it more transparent and easier to implement. 
If the block is not run (redis key is found) nil will be returned.
